### PR TITLE
Allow support for Guzzle 6 and 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin is required when working with some third party services in Winter CMS. Provides drivers used by services in Queue, Mail and Storage.
 
-The composer packages introduced by this plugin are listed below:
+The Composer packages introduced by this plugin are listed below:
 
 - **aws/aws-sdk-php** at version `~3.1`
 - **pda/pheanstalk** at version `~3.0`
@@ -10,4 +10,4 @@ The composer packages introduced by this plugin are listed below:
 - **predis/predis** at version `~1.0`
 - **league/flysystem-rackspace** at version `~1.0`
 - **league/flysystem-aws-s3-v3** at version `~1.0`
-- **guzzlehttp/guzzle** at version `~6.0`
+- **guzzlehttp/guzzle** at version `~6.3`, with optional support for version `~7.0`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# drivers-plugin
+# Third-party Drivers plugin
 
-This plugin is required when working with some third party services in Winter CMS. Provides drivers used by services in Queue, Mail and Storage.
+This plugin is required when working with some third party services in Winter CMS. Provides drivers used by services in Queue, Mail and Storage. It is intentionally left out by default in order to keep the number of Composer dependencies low in a default Winter CMS install.
 
 The Composer packages introduced by this plugin are listed below:
 
@@ -11,3 +11,11 @@ The Composer packages introduced by this plugin are listed below:
 - **league/flysystem-rackspace** at version `~1.0`
 - **league/flysystem-aws-s3-v3** at version `~1.0`
 - **guzzlehttp/guzzle** at version `~6.3`, with optional support for version `~7.0`.
+
+### Installation
+
+Run the following command in your Winter CMS installation directory:
+
+```
+composer require winter/wn-drivers-plugin
+```

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-aws-s3-v3": "~1.0",
 
-        "guzzlehttp/guzzle": "~7.3"
+        "guzzlehttp/guzzle": "~6.3 || ~7.0"
     },
     "extra": {
         "installer-name": "drivers"

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -6,3 +6,4 @@
 1.1.3: Update AWS library to version 3.1
 2.0.0: Rebrand to Winter.Drivers
 2.0.1: Update Guzzle library to version 7.3
+2.0.2: Bring back support for Guzzle library version 6.3 and above


### PR DESCRIPTION
Replaces 9ed59a9397d1e6202a73f209b420ef0d4045386b and allows any version of Guzzle 7.x, whilst still maintaining support for Guzzle >= 6.3