### PR TITLE
Update deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=7.0",
-        "composer/installers": "~1.0",
+        "composer/installers": "~1.1",
 
         "aws/aws-sdk-php": "~3.1",
         "pda/pheanstalk": "~3.0",
@@ -37,7 +37,7 @@
         "predis/predis": "~1.0",
 
         "league/flysystem-rackspace": "~1.0",
-        "league/flysystem-aws-s3-v3": "~1.0",
+        "league/flysystem-aws-s3-v3": "~3.0",
 
         "guzzlehttp/guzzle": "~6.3 || ~7.0"
     },


### PR DESCRIPTION
Updated `composer/installers` and `league/flysystem-aws-s3-v3` to their latest versions. Note that the latter pulls in `aws/aws-sdk-php` making it not only redundant to have listed, but tedious because we could pull two conflicting versions when updating deps in the future.