### PR TITLE
Removed in CMS 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "iron-io/iron_mq": "~1.5",
         "predis/predis": "~1.0",
 
-        "league/flysystem-rackspace": "~1.0",
         "league/flysystem-aws-s3-v3": "~1.0",
 
         "guzzlehttp/guzzle": "~6.3 || ~7.0"


### PR DESCRIPTION
This driver is no longer supported in CMS 1.2 as per https://github.com/wintercms/meta/blob/master/l9-upgrade-notes.md#storage--files

It also doesn't work with 1.2. See https://github.com/wintercms/wn-drivers-plugin/issues/5